### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,11 @@ can increment the package version using:
 Once you've incremented the version number, it'll offer to perform a commit on your behalf, so all you then need to do is push to GitHub.
 
 # Installing the package
-To install, run `renv::install("dfe-analytical-services/dfeshiny")`
+To install, run `renv::install("dfe-analytical-services/dfeshiny")`.
+
+## Potential errors when installing
+If you get `ERROR [curl: (22) The requested URL returned error: 401]`, and don't know why, try running `Sys.unsetenv("GITHUB_PAT")` to temporarily clear your GitHub PAT variable.
+
+Then try to install again. 
+
+If this works, then you will need to look for where that "GITHUB_PAT" variable is being set from and remove it to permanently fix the issue, contact us for support if you need help with this or have any other issues installing.

--- a/README.md
+++ b/README.md
@@ -3,15 +3,13 @@ R package containing preferred methods for creating official DfE R-Shiny dashboa
 
 # Contributing
 
-** Try and make use of the `usethis` package wherever relevant: (https://usethis.r-lib.org/)[https://usethis.r-lib.org/].
-
+Try and make use of the [usethis](https://usethis.r-lib.org/) package wherever possible.
 
 ## Adding a package/dependency
 
 `usethis::use_package(<package_name>)`
 
 This will create a new script within the package R/ folder.
-
 
 ## Creating a new script
 
@@ -29,4 +27,4 @@ can increment the package version using:
 Once you've incremented the version number, it'll offer to perform a commit on your behalf, so all you then need to do is push to GitHub.
 
 # Installing the package
-To install, run `renv::install("git::https://github.com/dfe-analytical-services/dfeshiny")`
+To install, run `renv::install("dfe-analytical-services/dfeshiny")`


### PR DESCRIPTION
This is to undo what I had previously done in #9, and explained in https://github.com/dfe-analytical-services/shiny-template/pull/70.

Having re-read the [guidance on renv::install()](https://rstudio.github.io/renv/reference/install.html) (and other guidance more generally) to try to troubleshoot issues in deployment pipelines with the alternative install of `dfeshiny`, it seems that the original method was the recommended one.

![image](https://github.com/dfe-analytical-services/dfeshiny/assets/52536248/4b0b7fd2-da83-4fa5-a2f9-bcf8423cb163)

Given this, and starting to bang my head against a wall a bit, I switched to trying to work out my original error I was having locally (along with some others). Time to hold my hands up and admit I should have persevered with this more in the first place...

 - I had a rogue .Renviron file that was in my onedrive documents folder from years ago setting an outdated GitHub PAT (amongst other things)
 - I hadn't considered this as I'd moved to a new laptop recently, and didn't know I had anything set in onedrive folders that would have carried over to the new laptop

It now works with the original instructions. I've added a quick note at the bottom of the README too, to help others who may hit this issue.

