### PR TITLE
Increment version number to 0.5.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dfeshiny
 Title: DfE R Shiny Standards
-Version: 0.5.1.9000
+Version: 0.5.2
 Authors@R: c(
     person("Rich", "Bielby", , "richard.bielby@education.gov.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-9070-9969")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
-# dfeshiny (development version)
+# dfeshiny 0.5.2
 
-* Added `dfeshiny::header()` function which uses `shinyGovstyle::header()` but it
-automatically uses the DfE logo.
+* Added `dfeshiny::header()` function to produce a standardised header incorporating
+the current DfE logo. This is a wrapper function to shinyGovstyle::header(), reducing 
+the range of options.
 
 # dfeshiny 0.5.1
 


### PR DESCRIPTION
# Brief overview of changes

We did a development version number on the last PR, but have been seeing issues with dfeshiny installing on ShinyApps.io ever since. Doesn't seem to be anything wrong when running devtools and it installs fine for people locally, so just wondering if the development version number is confusing renv on ShinyApps. I've ticked the version across from 0.5.1.9000 -> 0.5.2 to see if it helps.

## Why are these changes being made?

The push to ShinyApps.io part of the GitHub Actions workflow produces this fail:

> /mntError: Unhandled Exception: child_task=1483827003 child_task_status=failed: 
> Error building image: 
> Error fetching dfeshiny (0.5.1.9000) source. 
> \<GitHubPackage user='dfe-analytical-services' repo='dfeshiny' private=False\>
> unable to satisfy package: dfeshiny (0.5.1...


https://github.com/dfe-analytical-services/lsip_dashboard/actions/runs/12086941965/job/33709349101