### PR TITLE
Relax disconnect and cookies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,6 @@ Imports:
     glue,
     htmltools,
     magrittr,
-    RCurl,
     shiny,
     shinyGovstyle,
     shinyjs,

--- a/R/cookies.R
+++ b/R/cookies.R
@@ -159,8 +159,10 @@ cookies_banner_ui <- function(id = "cookies_banner", name = "DfE R-Shiny dashboa
 #' always be `parent_session = session`
 #' @param google_analytics_key Provide the GA 10 digit key of the form
 #' "ABCDE12345"
-#' @param cookies_link_panel name of the navlistPanel that the cookie banner
+#' @param cookies_link_panel name of the navigation panel that the cookie banner
 #' provides a link to, usually "cookies_panel_ui"
+#' @param cookies_nav_id ID of the navigation panel the cookie panel page is
+#' within, defaults to "navlistPanel"
 #'
 #' @family cookies
 #' @return NULL
@@ -172,7 +174,8 @@ cookies_banner_server <- function(
     input_cookies,
     parent_session,
     google_analytics_key = NULL,
-    cookies_link_panel = "cookies_panel_ui") {
+    cookies_link_panel = "cookies_panel_ui",
+    cookies_nav_id = "navlistPanel") {
   shiny::moduleServer(id, function(input, output, session) {
     if (is.null(google_analytics_key)) {
       warning("Please provide a valid Google Analytics key")
@@ -230,7 +233,7 @@ cookies_banner_server <- function(
       # updateTabsetPanel to have a cookie page for instance
       shiny::updateTabsetPanel(
         session = parent_session,
-        "navlistPanel",
+        inputID = cookies_nav_id,
         selected = cookies_link_panel
       )
     })

--- a/R/custom_disconnect_message.R
+++ b/R/custom_disconnect_message.R
@@ -11,6 +11,8 @@
 #' @param publication_link The link to the publication on Explore Education
 #' Statistics
 #' @param dashboard_title Title of the dashboard
+#' @param support_contact Email address for support contact, defaults to
+#' explore.statistics@@education.gov.uk
 #'
 #' @importFrom htmltools tags tagList
 #'
@@ -44,9 +46,9 @@ custom_disconnect_message <- function(
     dashboard_title = NULL,
     links = NULL,
     publication_name = NULL,
-    publication_link = NULL) {
+    publication_link = NULL,
+    support_contact = "explore.statistics@education.gov.uk") {
   # Check links are valid
-
   is_valid_sites_list <- function(sites) {
     lapply(
       stringr::str_trim(sites), startsWith,
@@ -59,12 +61,12 @@ custom_disconnect_message <- function(
     stop("You have entered an invalid site link in the links argument.")
   }
 
-
   pub_prefix <- c(
     "https://explore-education-statistics.service.gov.uk/find-statistics/",
     "https://www.explore-education-statistics.service.gov.uk/find-statistics/",
     "https://www.gov.uk/",
-    "https://gov.uk/"
+    "https://gov.uk/",
+    "https://github.com/dfe-analytical-services/"
   )
 
   if (!is.null(publication_link)) {
@@ -72,13 +74,14 @@ custom_disconnect_message <- function(
       startsWith(stringr::str_trim(link), pub_prefix)
     }
 
-    if (RCurl::url.exists(publication_link) == FALSE ||
-      (TRUE %in% is_valid_publication_link(publication_link)) == FALSE || # nolint: [indentation_linter]
-      publication_link %in% pub_prefix) {
+    if (TRUE %in% is_valid_publication_link(publication_link) == FALSE ||
+      publication_link %in% pub_prefix) { # nolint: [indentation_linter]
       stop("You have entered an invalid publication link in the publication_link
          argument.")
     }
   }
+
+  # TODO: Add email validation once a11y panel PR is in
 
   checkmate::assert_string(refresh)
 
@@ -126,21 +129,29 @@ custom_disconnect_message <- function(
             ". Apologies for the inconvenience."
           )
         },
-        if (!is.null(publication_name)) {
+        if (!is.null(publication_name) && grepl("explore-education-statistics", publication_link)) {
           tags$p(
-            "All the data used in this dashboard can also be viewed or downloaded via the ",
+            "The data used in this dashboard can also be viewed or downloaded via the ",
             dfeshiny::external_link(
               href = publication_link,
               publication_name
             ),
-            " on Explore Education Statistics."
+            " on explore education statistics."
+          )
+        } else if (!is.null(publication_name)) {
+          tags$p(
+            "The data used in this dashboard can also be viewed or downloaded from ",
+            dfeshiny::external_link(
+              href = publication_link,
+              publication_name
+            )
           )
         },
         tags$p(
           "Feel free to contact ",
           dfeshiny::external_link(
-            href = "mailto:explore.statistics@education.gov.uk",
-            "explore.statistics@education.gov.uk",
+            href = paste0("mailto:", support_contact),
+            support_contact,
             add_warning = FALSE
           ),
           " if you require further support."

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -6,7 +6,6 @@ DfE
 GDS
 Lifecycle
 README
-RSConnect
 UI
 WCAG
 analytics
@@ -22,6 +21,7 @@ javascript
 js
 lockfile
 md
+nav
 navlistPanel
 pkgdown
 renv

--- a/man/cookies_banner_server.Rd
+++ b/man/cookies_banner_server.Rd
@@ -9,7 +9,8 @@ cookies_banner_server(
   input_cookies,
   parent_session,
   google_analytics_key = NULL,
-  cookies_link_panel = "cookies_panel_ui"
+  cookies_link_panel = "cookies_panel_ui",
+  cookies_nav_id = "navlistPanel"
 )
 }
 \arguments{
@@ -25,8 +26,11 @@ always be \code{parent_session = session}}
 \item{google_analytics_key}{Provide the GA 10 digit key of the form
 "ABCDE12345"}
 
-\item{cookies_link_panel}{name of the navlistPanel that the cookie banner
+\item{cookies_link_panel}{name of the navigation panel that the cookie banner
 provides a link to, usually "cookies_panel_ui"}
+
+\item{cookies_nav_id}{ID of the navigation panel the cookie panel page is
+within, defaults to "navlistPanel"}
 }
 \description{
 cookies_banner_server() provides the server module to be used alongside

--- a/man/custom_disconnect_message.Rd
+++ b/man/custom_disconnect_message.Rd
@@ -10,7 +10,8 @@ custom_disconnect_message(
   links = NULL,
   publication_name = NULL,
   publication_link = NULL,
-  support_contact = "explore.statistics@education.gov.uk"
+  support_contact = "explore.statistics@education.gov.uk",
+  custom_refresh = NULL
 )
 }
 \arguments{
@@ -28,6 +29,10 @@ Statistics}
 
 \item{support_contact}{Email address for support contact, defaults to
 explore.statistics@education.gov.uk}
+
+\item{custom_refresh}{Custom refresh link, defaults to refreshing the page, main value is if you
+have bookmarking enabled and want the refresh to send to the initial view instead of reloading
+any bookmarks}
 }
 \value{
 A HTML overlay panel that appears when a user loses connection to a DfE R Shiny
@@ -57,4 +62,8 @@ custom_disconnect_message(
   )
 )
 
+custom_disconnect_message(
+  support_contact = "my.team@education.gov.uk",
+  custom_refresh = "https://department-for-education.shinyapps.io/my-dashboard"
+)
 }

--- a/man/custom_disconnect_message.Rd
+++ b/man/custom_disconnect_message.Rd
@@ -9,7 +9,8 @@ custom_disconnect_message(
   dashboard_title = NULL,
   links = NULL,
   publication_name = NULL,
-  publication_link = NULL
+  publication_link = NULL,
+  support_contact = "explore.statistics@education.gov.uk"
 )
 }
 \arguments{
@@ -24,6 +25,9 @@ but can be two URLs if an overflow site has been set up}
 
 \item{publication_link}{The link to the publication on Explore Education
 Statistics}
+
+\item{support_contact}{Email address for support contact, defaults to
+explore.statistics@education.gov.uk}
 }
 \value{
 A HTML overlay panel that appears when a user loses connection to a DfE R Shiny

--- a/tests/testthat/test-custom_disconnect_message.R
+++ b/tests/testthat/test-custom_disconnect_message.R
@@ -151,3 +151,31 @@ test_that("If the link contains EES it uses the EES text", {
     grepl("explore education statistics", paste0(ees_test), fixed = TRUE)
   )
 })
+
+test_that("Can customise refresh link, but not too much", {
+  expect_no_error(
+    custom_disconnect_message(
+      custom_refresh = "https://department-for-education.shinyapps.io/dfe-shiny-template/",
+    )
+  )
+
+  expect_error(
+    custom_disconnect_message(
+      custom_refresh = "https://www.google.com",
+    ),
+    paste0(
+      "You have entered an invalid site link in the custom_refresh argument.",
+      " It must be a site on shinyapps.io."
+    )
+  )
+
+  expect_error(
+    custom_disconnect_message(
+      custom_refresh = "https://github.com/dfe-analytical-services/dfeshiny",
+    ),
+    paste0(
+      "You have entered an invalid site link in the custom_refresh argument.",
+      " It must be a site on shinyapps.io."
+    )
+  )
+})

--- a/tests/testthat/test-custom_disconnect_message.R
+++ b/tests/testthat/test-custom_disconnect_message.R
@@ -19,16 +19,7 @@ test_that("publication link is valid", {
     )
   )
 
-  # Test that it fails for non-existent links/typos/random links
-  expect_error(
-    custom_disconnect_message(
-      refresh = "Refresh page",
-      links = "https://department-for-education.shinyapps.io/dfe-shiny-template/", # nolint: [line_length_linter]
-      publication_name = "Pupil attendance in schools",
-      publication_link = "https://explore-education-statistics.service.gov.uk/find-statistics/hello" # nolint: [line_length_linter]
-    )
-  )
-
+  # Test that it fails for a random link
   expect_error(
     custom_disconnect_message(
       refresh = "Refresh page",
@@ -39,7 +30,6 @@ test_that("publication link is valid", {
   )
 
   # Test that just linking to EES homepage fails
-
   expect_error(
     custom_disconnect_message(
       refresh = "Refresh page",
@@ -118,5 +108,46 @@ test_that("site links are valid", {
       publication_name = "Pupil attendance in schools",
       publication_link = "https://explore-education-statistics.service.gov.uk/find-statistics/pupil-attendance-in-schools" # nolint: [line_length_linter]
     )
+  )
+})
+
+test_that("Allows GitHub as publication_link and doesn't show EES text", {
+  expect_no_error(
+    custom_disconnect_message(
+      refresh = "Refresh page",
+      links = c(
+        "https://department-for-education.shinyapps.io/dfe-shiny-template/"
+      ),
+      publication_name = "Local authority interactive tool",
+      publication_link = "https://github.com/dfe-analytical-services/local-authority-interactive-tool" # nolint: [line_length_linter]
+    )
+  )
+
+  non_ees <- custom_disconnect_message(
+    refresh = "Refresh page",
+    links = c(
+      "https://department-for-education.shinyapps.io/dfe-shiny-template/"
+    ),
+    publication_name = "Local authority interactive tool",
+    publication_link = "https://github.com/dfe-analytical-services/local-authority-interactive-tool" # nolint: [line_length_linter]
+  )
+
+  expect_false(
+    grepl("explore education statistics", paste0(non_ees), fixed = TRUE)
+  )
+})
+
+test_that("If the link contains EES it uses the EES text", {
+  ees_test <- custom_disconnect_message(
+    refresh = "Refresh page",
+    links = c(
+      "https://department-for-education.shinyapps.io/dfe-shiny-template/"
+    ),
+    publication_name = "Local authority interactive tool",
+    publication_link = "https://www.explore-education-statistics.service.gov.uk/find-statistics/local-authority-interactive-tool" # nolint: [line_length_linter]
+  )
+
+  expect_true(
+    grepl("explore education statistics", paste0(ees_test), fixed = TRUE)
   )
 })

--- a/vignettes/implementing-cookies.Rmd
+++ b/vignettes/implementing-cookies.Rmd
@@ -99,6 +99,8 @@ dfeshiny::cookies_panel_server(
 )
 ```
 
+The ID for the UI panels is `navlistPanel`, and this is the default setting in the _server functions, if this ID is different, you will need to set cookie_nav_id in `cookies_panel_server()` to match your ID in the UI.
+
 In the above you should keep all of the flags as they are shown. Note that this 
 assumes you have added `google_analytics_key` as a declared variable in your 
 global.R file. If you've not done this, you'll need to replace 


### PR DESCRIPTION
# Brief overview of changes

Resolves #67 and resolves #68 by adding additional arguments to customise the disconnect message and the cookies panel.

## Why are these changes being made?

To allow more flexibility for non-EES dashboards, and to relax an overly strict ID requirement for cookies pages.

## Detailed description of changes

1. Remove RCurl as it takes time to run, and is overly strict for the checking we need (means we can drop a dependency too!)
2. Allow IDs other than navlistPanel to be used for the navigation tabset a cookies panel is within (before it could only be that, but we didn't document that anywhere)
3. Add a support_contact email address option, if a team wants to put their own email on the disconnect message
4. Add a custom_refresh option for where sites have bookmarking enabled and want the raw site URL to be the refreshed link 

For example if the bookmarking or those specific options are what caused the error, reloading them exactly will just make it error again.

## Additional information for reviewers

Some overlaps with #64 - I think there's clean up of the validation that can be done once that PR is in.

## Issue ticket number/s and link

#67 and #68, both raised by Jake when making the LAIT dashboard.
