### PR TITLE
add UI test for cookies information link

### DIFF
--- a/tests/test_dashboard/tests/testthat/_snaps/UI-02-cookies/cookies_consent-002.json
+++ b/tests/test_dashboard/tests/testthat/_snaps/UI-02-cookies/cookies_consent-002.json
@@ -1,14 +1,14 @@
 {
   "input": {
     "cookies": {
-      "dfe_analytics": "denied"
+      "dfe_analytics": "granted"
     },
     "cookies_banner-cookies_accept": 1,
-    "cookies_banner-cookies_link": 0,
-    "cookies_banner-cookies_reject": 1,
-    "cookies_panel-cookies_analytics": "no",
+    "cookies_banner-cookies_link": 1,
+    "cookies_banner-cookies_reject": 0,
+    "cookies_panel-cookies_analytics": "yes",
     "cookies_panel-submit_btn": 0,
-    "navlistPanel": "support_panel"
+    "navlistPanel": "cookies_panel_ui"
   },
   "output": {
 

--- a/tests/test_dashboard/tests/testthat/_snaps/UI-02-cookies/cookies_consent-003.json
+++ b/tests/test_dashboard/tests/testthat/_snaps/UI-02-cookies/cookies_consent-003.json
@@ -1,14 +1,14 @@
 {
   "input": {
     "cookies": {
-      "dfe_analytics": "granted"
+      "dfe_analytics": "denied"
     },
     "cookies_banner-cookies_accept": 1,
-    "cookies_banner-cookies_link": 0,
+    "cookies_banner-cookies_link": 1,
     "cookies_banner-cookies_reject": 1,
-    "cookies_panel-cookies_analytics": "yes",
-    "cookies_panel-submit_btn": 1,
-    "navlistPanel": "support_panel"
+    "cookies_panel-cookies_analytics": "no",
+    "cookies_panel-submit_btn": 0,
+    "navlistPanel": "cookies_panel_ui"
   },
   "output": {
 

--- a/tests/test_dashboard/tests/testthat/_snaps/UI-02-cookies/cookies_consent-004.json
+++ b/tests/test_dashboard/tests/testthat/_snaps/UI-02-cookies/cookies_consent-004.json
@@ -1,14 +1,14 @@
 {
   "input": {
     "cookies": {
-      "dfe_analytics": "denied"
+      "dfe_analytics": "granted"
     },
     "cookies_banner-cookies_accept": 1,
-    "cookies_banner-cookies_link": 0,
+    "cookies_banner-cookies_link": 1,
     "cookies_banner-cookies_reject": 1,
-    "cookies_panel-cookies_analytics": "no",
-    "cookies_panel-submit_btn": 2,
-    "navlistPanel": "support_panel"
+    "cookies_panel-cookies_analytics": "yes",
+    "cookies_panel-submit_btn": 1,
+    "navlistPanel": "cookies_panel_ui"
   },
   "output": {
 

--- a/tests/test_dashboard/tests/testthat/_snaps/UI-02-cookies/cookies_consent-005.json
+++ b/tests/test_dashboard/tests/testthat/_snaps/UI-02-cookies/cookies_consent-005.json
@@ -1,13 +1,13 @@
 {
   "input": {
     "cookies": {
-
+      "dfe_analytics": "denied"
     },
-    "cookies_banner-cookies_accept": 0,
+    "cookies_banner-cookies_accept": 1,
     "cookies_banner-cookies_link": 1,
-    "cookies_banner-cookies_reject": 0,
+    "cookies_banner-cookies_reject": 1,
     "cookies_panel-cookies_analytics": "no",
-    "cookies_panel-submit_btn": 0,
+    "cookies_panel-submit_btn": 2,
     "navlistPanel": "cookies_panel_ui"
   },
   "output": {

--- a/tests/test_dashboard/tests/testthat/test-UI-02-cookies.R
+++ b/tests/test_dashboard/tests/testthat/test-UI-02-cookies.R
@@ -7,36 +7,37 @@ app <- AppDriver$new(
 
 app$wait_for_idle(50)
 
-app$click("cookies_banner-cookies_accept")
-app$wait_for_idle(50)
+test_that("Can click view cookie information", {
+  app$click("cookies_banner-cookies_link")
+  app$wait_for_idle(50)
+  app$expect_values()
+})
 
 test_that("Cookies accepted banner", {
+  app$click("cookies_banner-cookies_accept")
+  app$wait_for_idle(50)
   app$expect_values()
 })
 
-app$click("cookies_banner-cookies_reject")
-app$wait_for_idle(50)
 
 test_that("Cookies rejected banner", {
+  app$click("cookies_banner-cookies_reject")
+  app$wait_for_idle(50)
   app$expect_values()
 })
-
-app$set_inputs(`cookies_panel-cookies_analytics` = "yes")
-app$wait_for_idle(50)
-
-app$click("cookies_panel-submit_btn")
-app$wait_for_idle(50)
 
 test_that("Cookies accepted page", {
+  app$set_inputs(`cookies_panel-cookies_analytics` = "yes")
+  app$wait_for_idle(50)
+  app$click("cookies_panel-submit_btn")
+  app$wait_for_idle(50)
   app$expect_values()
 })
 
-app$set_inputs(`cookies_panel-cookies_analytics` = "no")
-app$wait_for_idle(50)
-
-app$click("cookies_panel-submit_btn")
-app$wait_for_idle(50)
-
 test_that("Cookies rejected page", {
+  app$set_inputs(`cookies_panel-cookies_analytics` = "no")
+  app$wait_for_idle(50)
+  app$click("cookies_panel-submit_btn")
+  app$wait_for_idle(50)
   app$expect_values()
 })

--- a/tests/test_dashboard/tests/testthat/test-UI-02-cookies.R
+++ b/tests/test_dashboard/tests/testthat/test-UI-02-cookies.R
@@ -1,5 +1,5 @@
 # To run the diffviewer on these tests, you need to add the path:
-# testthat::snapshot_review('UI-02-cookies/', path='tests/test_dashboard/tests/testthat')
+# this - testthat::snapshot_review('UI-02-cookies/', path='tests/test_dashboard/tests/testthat')
 app <- AppDriver$new(
   name = "cookies_consent",
   expect_values_screenshot_args = FALSE

--- a/tests/test_dashboard/tests/testthat/test-UI-02-cookies.R
+++ b/tests/test_dashboard/tests/testthat/test-UI-02-cookies.R
@@ -1,5 +1,5 @@
 # To run the diffviewer on these tests, you need to add the path:
-# Doesn't work? testthat::snapshot_review('UI-02-cookies/', path='tests/test_dashboard/')
+# testthat::snapshot_review('UI-02-cookies/', path='tests/test_dashboard/tests/testthat')
 app <- AppDriver$new(
   name = "cookies_consent",
   expect_values_screenshot_args = FALSE

--- a/tests/test_dashboard/tests/testthat/test-UI-02-cookies.R
+++ b/tests/test_dashboard/tests/testthat/test-UI-02-cookies.R
@@ -1,5 +1,5 @@
 # To run the diffviewer on these tests, you need to add the path:
-# this - testthat::snapshot_review('UI-02-cookies/', path='tests/test_dashboard/tests/testthat')
+# like this! testthat::snapshot_review('UI-02-cookies/', path='tests/test_dashboard/tests/testthat')
 app <- AppDriver$new(
   name = "cookies_consent",
   expect_values_screenshot_args = FALSE


### PR DESCRIPTION
# Brief overview of changes

Related to #77, adding a quick test into our test dashboard to make sure we don't make the same mistake again.

## Why are these changes being made?

We'd made a typo in one of the ID arguments in the cookies functions and had released it without realising, adding the test coverage will help prevent that.

## Detailed description of changes

In the existing cookies UI test it now clicks that link and takes a snapshot before doing the rest of the interactions.

## Additional information for reviewers

When initially raised, prior to #77 being merged, this was failing, so would have highlighted to us we have an issue. 

#77 is now merged, so I've rebased this branch on top and the tests are now passing as Jake fixed the issue in #77.

I've also added @JT-39 to the repo with write permissions so in future they can create new branches and review PRs, feels deserved given their contributions!

## Issue ticket number/s and link

Resolves #75 by preventing us doing it again.
