### PR TITLE
hide shiny disconnect message

### DIFF
--- a/R/custom_disconnect_message.R
+++ b/R/custom_disconnect_message.R
@@ -123,8 +123,20 @@ custom_disconnect_message <- function(
         "  $(document).on('shiny:disconnected', function(event) {",
         "    $('#custom-disconnect-dialog').show();",
         "    $('#ss-overlay').show();",
-        "  })",
+        "  });",
         "});"
+      )
+    ),
+    tags$head(
+      tags$style(
+        HTML(
+          "
+          /* Hide the default Shiny disconnect message */
+          #shiny-disconnected-overlay {
+              display: none !important;
+          }
+          "
+        )
       )
     ),
     tags$div(

--- a/R/custom_disconnect_message.R
+++ b/R/custom_disconnect_message.R
@@ -129,7 +129,7 @@ custom_disconnect_message <- function(
     ),
     tags$head(
       tags$style(
-        HTML(
+        htmltools::HTML(
           "
           /* Hide the default Shiny disconnect message */
           #shiny-disconnected-overlay {


### PR DESCRIPTION
# Brief overview of changes

Updated the `custom_disconnect_message` function to hide the default Shiny disconnect message (`#shiny-disconnected-overlay`) and ensure only the custom disconnect message is displayed when the app disconnects.

## Detailed description of changes

- Added a CSS rule to hide the default Shiny disconnect overlay:
  ```css
  #shiny-disconnected-overlay {
      display: none !important;
  }
  ```