### PR TITLE
Update dashboard_deploy_template.yaml

### DIFF
--- a/.github/workflows/dashboard_deploy_template.yaml
+++ b/.github/workflows/dashboard_deploy_template.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Set environment variables based on branch
         run: |
-          if [[ "${{ github.ref_name }}" == "main" ]]; then
+          if [ "${{ github.ref_name }}" == "main" ]; then
             echo "SHINYAPP_NAME=$DASHBOARD_NAME" >> $GITHUB_ENV
           else
             echo "SHINYAPP_NAME=dev-$DASHBOARD_NAME" >> $GITHUB_ENV

--- a/.github/workflows/dashboard_deploy_template.yaml
+++ b/.github/workflows/dashboard_deploy_template.yaml
@@ -39,6 +39,7 @@ jobs:
           echo "DEPLOY_TARGET=$DEPLOY_TARGET" >> $GITHUB_ENV
 
       - name: Set environment variables based on branch
+        shell: bash
         run: |
           if [ "${{ github.ref_name }}" == "main" ]; then
             echo "SHINYAPP_NAME=$DASHBOARD_NAME" >> $GITHUB_ENV

--- a/.github/workflows/dashboard_deploy_template.yaml
+++ b/.github/workflows/dashboard_deploy_template.yaml
@@ -40,11 +40,7 @@ jobs:
 
       - name: Set environment variables based on branch
         run: |
-          if "${{ github.ref_name }}" == "main"; then
-            echo "SHINYAPP_NAME=$DASHBOARD_NAME" >> $GITHUB_ENV
-          else
-            echo "SHINYAPP_NAME=dev-$DASHBOARD_NAME" >> $GITHUB_ENV
-          fi
+          echo "SHINYAPP_NAME=$DASHBOARD_NAME" >> $GITHUB_ENV
 
       - name: Restore renv snapshot
         shell: Rscript {0}

--- a/.github/workflows/dashboard_deploy_template.yaml
+++ b/.github/workflows/dashboard_deploy_template.yaml
@@ -40,7 +40,11 @@ jobs:
 
       - name: Set environment variables based on branch
         run: |
-          echo "SHINYAPP_NAME=$DASHBOARD_NAME" >> $GITHUB_ENV
+          if [ "${{ github.ref_name }}" == "main" ]; then
+            echo "SHINYAPP_NAME=$DASHBOARD_NAME" >> $GITHUB_ENV
+          else
+            echo "SHINYAPP_NAME=dev-$DASHBOARD_NAME" >> $GITHUB_ENV
+          fi
 
       - name: Restore renv snapshot
         shell: Rscript {0}

--- a/.github/workflows/dashboard_deploy_template.yaml
+++ b/.github/workflows/dashboard_deploy_template.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Set environment variables based on branch
         run: |
-          if [ "${{ github.ref_name }}" == "main" ]; then
+          if "${{ github.ref_name }}" == "main"; then
             echo "SHINYAPP_NAME=$DASHBOARD_NAME" >> $GITHUB_ENV
           else
             echo "SHINYAPP_NAME=dev-$DASHBOARD_NAME" >> $GITHUB_ENV


### PR DESCRIPTION
# Brief overview of changes

If statement failed in deploy script, looks like it just returned a false due to the syntax used:

` [[: main: unexpected operator`

The result was that the condition was always false and so a dashboard always deployed to dev-* instead of the live dashboard.

Did a bit of digging and it looks like this is just the limited functionality of `sh` versus `bash`, so I've set the faulty bit of the pipeline to run in `bash`. I've tested this out on the attendance dashboard and it sets the deploy target successfully.

Attendance dashboard deploy triggered from main:
https://github.com/dfe-analytical-services/attendance-data-dashboard/actions/runs/12928294233/job/36057454809

Attendance dashboard deploy triggered from other branch:
https://github.com/dfe-analytical-services/attendance-data-dashboard/actions/runs/12928068789/job/36057911578


