### PR TITLE
Fix R version to 4.4.2

### DIFF
--- a/.github/workflows/dashboard_deploy_template.yaml
+++ b/.github/workflows/dashboard_deploy_template.yaml
@@ -29,6 +29,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
+          r-version: 4.4.2
       
       - name: Read parameters
         run: |


### PR DESCRIPTION
# Brief overview of changes

R has been updated to 4.4.3 and as usual the GitHub Actions / ShinyApps don't like the latest version yet, so manually fixing to v4.4.2 until they sort themselves out.

## Why are these changes being made?

Dashboard deploys fail with the latest R:
https://github.com/dfe-analytical-services/CSC_outcomes_and_enablers/actions/runs/13634906124/job/38111132769

And this is the same deploy passing after I've forced the deploy to 4.4.2:
https://github.com/dfe-analytical-services/CSC_outcomes_and_enablers/actions/runs/13651393067/job/38160569553

