### PR TITLE
Added dynamic dashboard path to automated tests workflow template

### DIFF
--- a/.github/workflows/automated_tests_template.yaml
+++ b/.github/workflows/automated_tests_template.yaml
@@ -12,6 +12,7 @@ on:
         description: "Is this part of a package"
         default: 'false'
         required: false
+        type: string
 
 
 jobs:

--- a/.github/workflows/automated_tests_template.yaml
+++ b/.github/workflows/automated_tests_template.yaml
@@ -8,6 +8,10 @@ on:
         default: "./"
         required: false
         type: string
+      is_package:
+        description: "Is this part of a package"
+        default: 'false'
+        required: false
 
 
 jobs:
@@ -33,6 +37,7 @@ jobs:
           r-version: 4.4.2
 
       - name: Install dependencies
+        if: ${{ inputs.is_package == 'true' }}
         uses: r-lib/actions/setup-r-dependencies@v2
 
       - name: Restore packages

--- a/.github/workflows/automated_tests_template.yaml
+++ b/.github/workflows/automated_tests_template.yaml
@@ -53,4 +53,4 @@ jobs:
         shell: Rscript {0}
         run: |
           chromote::local_chrome_version(binary = "chrome-headless-shell", quiet = FALSE)
-          shinytest2::test_app( ${{ inputs.dashboard_path }})
+          shinytest2::test_app( '${{ inputs.dashboard_path }}')

--- a/.github/workflows/automated_tests_template.yaml
+++ b/.github/workflows/automated_tests_template.yaml
@@ -1,7 +1,14 @@
 name: Dashboard Deploy
 
 on:
-  workflow_call
+  workflow_call:
+    inputs:
+      dashboard_path:
+        description: "Path to dashboard"
+        default: "./"
+        required: false
+        type: string
+
 
 jobs:
   automatedTests:
@@ -39,4 +46,4 @@ jobs:
         shell: Rscript {0}
         run: |
           chromote::local_chrome_version(binary = "chrome-headless-shell", quiet = FALSE)
-          shinytest2::test_app()
+          shinytest2::test_app( ${{ inputs.dashboard_path }})

--- a/.github/workflows/automated_tests_template.yaml
+++ b/.github/workflows/automated_tests_template.yaml
@@ -32,11 +32,18 @@ jobs:
           use-public-rspm: true
           r-version: 4.4.2
 
-      - name: Restore renv snapshot
+      - name: Install dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+
+      - name: Restore packages
         shell: Rscript {0}
         run: |
           if (!requireNamespace("renv", quietly = TRUE)) install.packages("renv")
-          renv::restore()
+          if (file.exists("renv.lock")){
+             renv::restore()
+          } else {
+             warning("No renv.lock file found")
+          }
           renv::install("rstudio/chromote")
 
       - name: Set Chromote to new headless mode

--- a/.github/workflows/test_dashboard.yaml
+++ b/.github/workflows/test_dashboard.yaml
@@ -11,3 +11,4 @@ jobs:
     uses: dfe-analytical-services/dfeshiny/.github/workflows/automated_tests_template.yaml@bugfix/automated-test-workflow
     with:
       dashboard_path: "./tests/test_dashboard/"
+      is_package: "true"

--- a/.github/workflows/test_dashboard.yaml
+++ b/.github/workflows/test_dashboard.yaml
@@ -6,6 +6,8 @@ on:
 
 name: Test dashboard
 
+jobs:
+  automatedTests:
     uses: dfe-analytical-services/dfeshiny/.github/workflows/automated_tests_template.yaml@bugfix/automated-test-workflow
     with:
       dashboard_path: "./tests/test_dashboard/"

--- a/.github/workflows/test_dashboard.yaml
+++ b/.github/workflows/test_dashboard.yaml
@@ -6,41 +6,6 @@ on:
 
 name: Test dashboard
 
-jobs:
-  automatedTests:
-    runs-on: ${{ matrix.config.os }}
-
-    name: shiny-tests
-
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - {os: ubuntu-latest, r: 'release'}
-
-    env:
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      RSPM: ${{ matrix.config.rspm }}
-      RENV_PATHS_ROOT: ~/.local/share/renv
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-
-      - name: Install dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2
-
-      - name: Run tests
-        shell: Rscript {0}
-        run: |
-          shiny::runTests("tests/test_dashboard", assert = TRUE)
-
-      - name: Upload test results
-        if: failure()
-        uses: actions/upload-artifact@master
-        with:
-          name: ${{ runner.os }}-r${{ matrix.config.r }}-tests
-          path: tests
+    uses: dfe-analytical-services/dfeshiny/.github/workflows/automated_tests_template.yaml@bugfix/automated-test-workflow
+    with:
+      dashboard_path: "./tests/test_dashboard/"


### PR DESCRIPTION
# Brief overview of changes

The automated tests were failing on the dfeshiny test-dashboard. I'd already fixed this on some dashboards by creating the template automated tests workflow in dfeshiny, but hadn't applied that to dfeshiny's own test dashboard tests. This PR plugs that oversight by:
- Adapts the template to take a dashboard_path input allowing for dashboards to be outside of the root folder (e.g. like dfeshiny and shinyGovstyle)
- Shifts dfeshiny's own automated test to actually use it's own automated test template.

## Why are these changes being made?

Neatness. So that the tests work.

## Additional information for reviewers

...

## Issue ticket number/s and link

...
