### PR TITLE
Adding ... as an option in header() in order to allow additional params to shinyGovstyle::header()

### DIFF
--- a/R/header.R
+++ b/R/header.R
@@ -5,6 +5,7 @@
 #' using the DfE logo.
 #'
 #' @param header Text to use for the header of the dashboard
+#' @param ... Further arguments passed to shinyGovstyle::header()
 #' @return a header html shiny object
 #'
 #' @seealso [shinyGovstyle::header()]
@@ -22,13 +23,14 @@
 #'
 #'   shinyApp(ui = ui, server = server)
 #' }
-header <- function(header) {
+header <- function(header, ...) {
   shinyGovstyle::header(
     logo = "dfeshiny/DfE_logo_landscape.png",
     main_text = "",
     secondary_text = header,
     main_link = "https://www.gov.uk/government/organisations/department-for-education",
     logo_width = 132.98,
-    logo_height = 32
+    logo_height = 32,
+    ...
   )
 }

--- a/man/header.Rd
+++ b/man/header.Rd
@@ -4,10 +4,12 @@
 \alias{header}
 \title{DfE header banner}
 \usage{
-header(header)
+header(header, ...)
 }
 \arguments{
 \item{header}{Text to use for the header of the dashboard}
+
+\item{...}{Further arguments passed to shinyGovstyle::header()}
 }
 \value{
 a header html shiny object

--- a/tests/testthat/test-header.R
+++ b/tests/testthat/test-header.R
@@ -19,3 +19,14 @@ test_that("outputs are as expected", {
     "dfeshiny/DfE_logo_landscape.png"
   )
 })
+
+test_that("Header handles additional shinyGovstyle header inputs",{
+  expect_equal(
+    header(
+      "Site title",
+      secondary_link = "https://explore-education-statistics.service.gov.uk/"
+      )$children[[2]][[3]][[2]][[3]][[1]]$attribs$href,
+    "https://explore-education-statistics.service.gov.uk/"
+  )
+}
+)

--- a/tests/testthat/test-header.R
+++ b/tests/testthat/test-header.R
@@ -20,12 +20,12 @@ test_that("outputs are as expected", {
   )
 })
 
-test_that("Header handles additional shinyGovstyle header inputs",{
+test_that("Header handles additional shinyGovstyle header inputs", {
   expect_equal(
     header(
       "Site title",
       secondary_link = "https://explore-education-statistics.service.gov.uk/"
-      )$children[[2]][[3]][[2]][[3]][[1]]$attribs$href,
+    )$children[[2]][[3]][[2]][[3]][[1]]$attribs$href,
     "https://explore-education-statistics.service.gov.uk/"
   )
 }


### PR DESCRIPTION
# Brief overview of changes

We've got a slight disconnect at the moment in terms of shinyGovstyle development version throwing an error if alt text is not provided for the logo, but the CRAN version doesn't yet have the alt text as an input option. At the same time dfeshiny doesn't pass any alt text because we want it to work with the CRAN version of shinyGovstyle. So at the moment the development version of shinyGovstyle is incompatible with dfeshiny if a dashboard is using dfeshiny::header().

I wanted a quick way around this for a dashboard I'm working with, so I've added ... as a param to dfeshiny::header(), so I can pass the alt text manually where I want to.

