### PR TITLE
Removing shinyapps token requirement from lintr workflow

### DIFF
--- a/.github/workflows/lintr_reusable.yaml
+++ b/.github/workflows/lintr_reusable.yaml
@@ -8,11 +8,6 @@ on:
         default: 'false'
         required: false
         type: string
-    secrets:
-      SHINYAPPS_SECRET:
-        required: true
-      SHINYAPPS_TOKEN:
-        required: true
 
 jobs:
   lintr:


### PR DESCRIPTION
# Brief overview of changes

Some unnecessary params crept in from the deploy workflow, so just removing them!

