### PR TITLE
Change lintr linting from directory to package

### DIFF
--- a/.github/workflows/lintr.yml
+++ b/.github/workflows/lintr.yml
@@ -16,6 +16,6 @@ permissions:
 
 jobs:
   lint:
-    uses: dfe-analytical-services/dfeshiny/.github/workflows/lintr_reusable.yaml@workflows/switch-lintr-to-pkg
+    uses: dfe-analytical-services/dfeshiny/.github/workflows/lintr_reusable.yaml@main
     with:
       is_package: "true"


### PR DESCRIPTION
# Brief overview of changes

Switching lintr run to use lintr_pkg instead of lintr_dir

## Why are these changes being made?

To tune lintr more towards a package set up

