### PR TITLE
Move shinygovstyle back to CRAN version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,8 +38,6 @@ Suggests:
     shinytest2,
     spelling,
     testthat (>= 3.0.0)
-Remotes: 
-    dfe-analytical-services/shinyGovstyle
 VignetteBuilder: 
     knitr
 Config/testthat/edition: 3

--- a/R/header.R
+++ b/R/header.R
@@ -25,10 +25,9 @@
 #' }
 header <- function(header, ...) {
   shinyGovstyle::header(
+    org_name = "Department for Education",
+    service_name = header,
     logo = "dfeshiny/DfE_logo_landscape.png",
-    main_text = "",
-    secondary_text = header,
-    main_link = "https://www.gov.uk/government/organisations/department-for-education",
     logo_width = 132.98,
     logo_height = 32,
     ...

--- a/tests/testthat/_snaps/header.md
+++ b/tests/testthat/_snaps/header.md
@@ -1,0 +1,23 @@
+# Snapshot is as expected
+
+    Code
+      header_output
+    Output
+      <header class="govuk-header" role="banner">
+        <style>.govuk-header__logotype-crown-fallback-image {width: 132.98px;
+            height: 32px;}.govuk-header__link:focus .govuk-header__logotype-crown-fallback-image, .govuk-header__link:active .govuk-header__logotype-crown-fallback-image {filter: invert(1);}</style>
+        <div class="govuk-header__container govuk-width-container">
+          <div class="govuk-header__logo">
+            <span>
+              <span class="govuk-header__logotype">
+                <img src="dfeshiny/DfE_logo_landscape.png" class="govuk-header__logotype-crown-fallback-image" alt="Departmental logo"/>
+                <span class="govuk-header__product-name">Department for Education</span>
+              </span>
+            </span>
+          </div>
+          <div class="govuk-header__content">
+            <span class="govuk-header__service-name">hello</span>
+          </div>
+        </div>
+      </header>
+

--- a/tests/testthat/test-header.R
+++ b/tests/testthat/test-header.R
@@ -1,32 +1,36 @@
-# create output for testing
-
-output <- dfeshiny::header(header = "hello")
-
+# Suppress known deprecation warnings
+header_output <- suppressWarnings(header(header = "hello"))
 
 test_that("outputs are as expected", {
-  expect_equal(
-    paste(
-      output$children[[2]]$children[[2]]$children[[1]]$children[[1]]
-    ),
-    "hello"
-  )
+  # Helper to recursively search for a tag by class
+  find_tag_by_class <- function(x, class_name) {
+    if (
+      is.list(x) && !is.null(x$attribs$class) && x$attribs$class == class_name
+    ) {
+      return(x)
+    }
+    if (is.list(x) && !is.null(x$children)) {
+      for (child in x$children) {
+        found <- find_tag_by_class(child, class_name)
+        if (!is.null(found)) return(found)
+      }
+    }
+    NULL
+  }
 
-  expect_equal(
-    paste(
-      output[["children"]][[2]][["children"]][[1]][["children"]][[1]]
-      [["children"]][[1]][["children"]][[1]][["attribs"]][["src"]]
-    ),
-    "dfeshiny/DfE_logo_landscape.png"
+  product_name <- find_tag_by_class(header_output, "govuk-header__product-name")
+  expect_false(is.null(product_name))
+  expect_equal(product_name$children[[1]], "Department for Education")
+
+  logo_img <- find_tag_by_class(
+    header_output,
+    "govuk-header__logotype-crown-fallback-image"
   )
+  if (!is.null(logo_img) && identical(logo_img$name, "img")) {
+    expect_equal(logo_img$attribs$src, "dfeshiny/DfE_logo_landscape.png")
+  }
 })
 
-test_that("Header handles additional shinyGovstyle header inputs", {
-  expect_equal(
-    header(
-      "Site title",
-      secondary_link = "https://explore-education-statistics.service.gov.uk/"
-    )$children[[2]][[3]][[2]][[3]][[1]]$attribs$href,
-    "https://explore-education-statistics.service.gov.uk/"
-  )
-}
-)
+test_that("Snapshot is as expected", {
+  expect_snapshot(header_output)
+})


### PR DESCRIPTION
# Brief overview of changes

Now shinyGovstyle is up to v0.2.0 on CRAN and relatively stable, we should move back to using that instead of the development version.

## Why are these changes being made?

Should protect dfeshiny from development changes in shinyGovstyle that could break or change things without warning, gives a clearer versioned point for the code to reference.

## Detailed description of changes

Also includes some updates based on breaking changes to the `header()` function.