### PR TITLE
Fix object_usage_linter false-positives by loading package before linting in one Rscript session

### DIFF
--- a/.github/workflows/lintr_reusable.yaml
+++ b/.github/workflows/lintr_reusable.yaml
@@ -44,15 +44,14 @@ jobs:
           renv::install("cyclocomp")
         shell: Rscript {0}
 
-      - name: Load package
+      - name: Load package and run lintr
         if: ${{ inputs.is_package == 'true' }}
-        run: devtools::load_all()
-        shell: Rscript {0}
-        continue-on-error: true
-
-      - name: Run lintr_pkg
-        if: ${{ inputs.is_package == 'true' }}
-        run: lintr::sarif_output(lintr::lint_package(), "lintr-results.sarif")
+        run: |
+          tryCatch(
+            devtools::load_all(),
+            error = function(e) message("load_all failed: ", conditionMessage(e))
+          )
+          lintr::sarif_output(lintr::lint_package(), "lintr-results.sarif")
         shell: Rscript {0}
         continue-on-error: true
 
@@ -63,7 +62,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: lintr-results.sarif
           wait-for-processing: true


### PR DESCRIPTION
## Overview of changes

The reusable lintr workflow runs `devtools::load_all()` and `lintr::lint_package()` in **two separate `Rscript {0}` steps**. Because each step is a fresh R process, the package namespace loaded in step 1 is lost by step 2. With the package not loaded, `object_usage_linter` flags internal package helpers (e.g. `attachDependency`) as "no visible global function definition", generating false-positive code scanning alerts.

**Fix:** merge the two `is_package == 'true'` steps into a single `Rscript` invocation so the loaded namespace is still in scope when lintr runs. A `tryCatch` around `load_all()` preserves the existing `continue-on-error: true` intent — SARIF is still uploaded if `load_all` fails, and the failure is visible in logs.

Also bumps `codeql-action/upload-sarif` from `v3` to `v4` (v3 is deprecated December 2026, which was already generating warnings in CI).

Verified in [dfe-analytical-services/shinyGovstyle#223](https://github.com/dfe-analytical-services/shinyGovstyle/pull/223): inlining this same fix in the caller reduced code scanning results from 5 false-positive alerts to 0.

The `is_package == 'false'` (renv/lintr_dir) path is unchanged.

## PR Checklist

- [x] I have updated the documentation (if needed) — workflow only, no docs
- [x] I have added or updated tests for these changes (if applicable) — not applicable for workflow change
- [x] I have tested these changes locally using `devtools::check()` — verified end-to-end on shinyGovstyle PR #223

## Reviewer instructions

After merge, the shinyGovstyle inline workaround in [.github/workflows/lintr.yml](https://github.com/dfe-analytical-services/shinyGovstyle/blob/fix/code-scanning-lintr-warnings/.github/workflows/lintr.yml) can be reverted to `uses: dfe-analytical-services/dfeshiny/.github/workflows/lintr_reusable.yaml@main`.