### PR TITLE
Update dashboard_deploy_template.yaml with renv snapshots

### DIFF
--- a/.github/workflows/dashboard_deploy_template.yaml
+++ b/.github/workflows/dashboard_deploy_template.yaml
@@ -53,11 +53,15 @@ jobs:
         run: |
           if (!requireNamespace("renv", quietly = TRUE)) install.packages("renv")
           renv::restore()
+          renv::snapshot()
 
       - name: Install rsconnect
         shell: Rscript {0}
         run: |
-          if (!requireNamespace("rsconnect", quietly = TRUE)) install.packages("rsconnect")
+          if (!requireNamespace("rsconnect", quietly = TRUE)) {
+             install.packages("rsconnect")
+             renv::snapshot()
+          }
 
       - name: Deploy to ShinyApps.io
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
# Brief overview of changes

I'm finding that the deploy stages are making updates to the packages and then ShinyApps complains that the snapshot is out of sync and fails the deploy.

The two areas where this seems to be an issue are:
- shinyGovstyle has a development version and renv keeps "fixing" the dependency tree to use it instead of the latest non-development version
- rsconnect is installed if not already present in order to run the final stage of deploy

I think the former is the actual culprit, but I'm not 100% so I've tried to implement something that covers both potential causes
