### PR TITLE
Fix accessibility panel

### DIFF
--- a/R/a11y_panel.R
+++ b/R/a11y_panel.R
@@ -221,10 +221,12 @@ a11y_panel <- function(
              accessibility requirements, contact us:"
     ),
     shinyGovstyle::gov_list(
-      shiny::tags$li(
-        shiny::tags$a(
-          href = "mailto:explore.statistics@education.gov.uk",
-          "explore.statistics@education.gov.uk"
+      list(
+        shiny::tags$li(
+          shiny::tags$a(
+            href = "mailto:explore.statistics@education.gov.uk",
+            "explore.statistics@education.gov.uk"
+          )
         )
       )
     ),

--- a/R/a11y_panel.R
+++ b/R/a11y_panel.R
@@ -220,13 +220,12 @@ a11y_panel <- function(
              If you find any problems not listed on this page or think we're not meeting
              accessibility requirements, contact us:"
     ),
-    shinyGovstyle::gov_list(
-      list(
-        shiny::tags$li(
-          shiny::tags$a(
-            href = "mailto:explore.statistics@education.gov.uk",
-            "explore.statistics@education.gov.uk"
-          )
+    shinyGovstyle::insert_text(
+      inputId = "contact_email",
+      content = shiny::tags$p(
+        shiny::tags$a(
+          href = "mailto:explore.statistics@education.gov.uk",
+          "explore.statistics@education.gov.uk"
         )
       )
     ),

--- a/R/a11y_panel.R
+++ b/R/a11y_panel.R
@@ -221,7 +221,7 @@ a11y_panel <- function(
              accessibility requirements, contact us:"
     ),
     shinyGovstyle::gov_list(
-      c(
+      shiny::tags$li(
         shiny::tags$a(
           href = "mailto:explore.statistics@education.gov.uk",
           "explore.statistics@education.gov.uk"

--- a/R/a11y_panel.R
+++ b/R/a11y_panel.R
@@ -155,7 +155,8 @@ a11y_panel <- function(
           "navigate most of the website using a keyboard or speech recognition software",
           "listen to most of the website using a screen reader
                     (including the most recent versions of JAWS, NVDA and VoiceOver)"
-        )
+        ),
+        style = "bullet"
       )
     ),
     shinyGovstyle::gov_text(
@@ -325,7 +326,8 @@ a11y_panel <- function(
           "navigation",
           "interactive dropdown selections",
           "charts, maps, and tables"
-        )
+        ),
+        style = "bullet"
       )
     ),
     shinyGovstyle::gov_text(


### PR DESCRIPTION
We have just had a report of an issue in the EES mailbox about the accessibility tab. Gemma Selby raised a presentation issue with the 'Feedback and contact information' section where it shows unwanted bullet points. So I felt that the e-mail link needed to be wrapped inside shiny::tags$li().