### PR TITLE
Bump version from 0.6.2 to 0.6.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dfeshiny
 Title: DfE R Shiny Standards
-Version: 0.6.2
+Version: 0.6.3
 Authors@R: c(
     person("Rich", "Bielby", , "richard.bielby@education.gov.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-9070-9969")),


### PR DESCRIPTION
# Brief overview of changes

Rolling over to v0.6.3 following the accessibility statement clean-up tasks.

